### PR TITLE
Fix path→base migration gaps in dependency resolution and validation

### DIFF
--- a/packages/core/src/core/package-management.ts
+++ b/packages/core/src/core/package-management.ts
@@ -369,10 +369,12 @@ function doesDependencyMatchPackageName(
     }
     
     const { username, repo } = githubInfo;
-    
-    // Get the actual path from dependency (prefer path over subdirectory)
-    const actualPath = dep.path || (dep.subdirectory?.startsWith('./') 
-      ? dep.subdirectory.substring(2) 
+
+    // Get the actual path from dependency. For git sources, base is the path within the repo.
+    // (Note: path field for git sources specifies resource selection, not the repo subdirectory)
+    // Fall back to deprecated subdirectory field for backward compatibility.
+    const actualPath = dep.base || (dep.subdirectory?.startsWith('./')
+      ? dep.subdirectory.substring(2)
       : dep.subdirectory);
     
     // Build all possible name variations that could match

--- a/packages/core/src/core/package-management.ts
+++ b/packages/core/src/core/package-management.ts
@@ -370,9 +370,7 @@ function doesDependencyMatchPackageName(
     
     const { username, repo } = githubInfo;
 
-    // Get the actual path from dependency. For git sources, base is the path within the repo.
-    // (Note: path field for git sources specifies resource selection, not the repo subdirectory)
-    // Fall back to deprecated subdirectory field for backward compatibility.
+    // For git sources, path is resource selection, not repo subdirectory
     const actualPath = dep.base || (dep.subdirectory?.startsWith('./')
       ? dep.subdirectory.substring(2)
       : dep.subdirectory);

--- a/packages/core/src/core/source-resolution/dependency-graph.ts
+++ b/packages/core/src/core/source-resolution/dependency-graph.ts
@@ -14,6 +14,7 @@ import type { DependencyGraphNode, ResolvedPackageSource } from './types.js';
 interface PackageDependency {
   name: string;
   version?: string;
+  base?: string;
   path?: string;
   git?: string;
   url?: string;
@@ -26,8 +27,12 @@ async function resolveFromManifest(
 ): Promise<ResolvedPackageSource> {
   const normalizedName = normalizePackageName(dep.name);
 
-  if (dep.path) {
-    const resolved = resolveDeclaredPath(dep.path, manifestDir);
+  // Check for local path dependency: base is the modern field (post-migration),
+  // path is the legacy field (pre-migration). Either indicates a local source.
+  if (dep.base || dep.path) {
+    // Prefer base (modern) over path (legacy fallback for old manifests)
+    const pathToResolve = dep.base ?? dep.path!;
+    const resolved = resolveDeclaredPath(pathToResolve, manifestDir);
     const absolutePath = path.join(resolved.absolute, path.sep);
     const mutability = isRegistryPath(absolutePath) ? MUTABILITY.IMMUTABLE : MUTABILITY.MUTABLE;
     const sourceType = isRegistryPath(absolutePath) ? SOURCE_TYPES.REGISTRY : SOURCE_TYPES.PATH;

--- a/packages/core/src/core/source-resolution/dependency-graph.ts
+++ b/packages/core/src/core/source-resolution/dependency-graph.ts
@@ -10,16 +10,7 @@ import { cloneGitToRegistry } from '../git-clone-registry.js';
 import { resolveNamedDependency } from './resolve-named-dependency.js';
 import { resolvePackageSource } from './resolve-package-source.js';
 import type { DependencyGraphNode, ResolvedPackageSource } from './types.js';
-
-interface PackageDependency {
-  name: string;
-  version?: string;
-  base?: string;
-  path?: string;
-  git?: string;
-  url?: string;
-  ref?: string;
-}
+import type { PackageDependency } from '../../types/index.js';
 
 async function resolveFromManifest(
   manifestDir: string,
@@ -27,10 +18,7 @@ async function resolveFromManifest(
 ): Promise<ResolvedPackageSource> {
   const normalizedName = normalizePackageName(dep.name);
 
-  // Check for local path dependency: base is the modern field (post-migration),
-  // path is the legacy field (pre-migration). Either indicates a local source.
   if (dep.base || dep.path) {
-    // Prefer base (modern) over path (legacy fallback for old manifests)
     const pathToResolve = dep.base ?? dep.path!;
     const resolved = resolveDeclaredPath(pathToResolve, manifestDir);
     const absolutePath = path.join(resolved.absolute, path.sep);

--- a/packages/core/src/utils/validation/dependency-containment.ts
+++ b/packages/core/src/utils/validation/dependency-containment.ts
@@ -30,8 +30,8 @@ export interface ContainmentResult {
 /**
  * Validate that all local path dependencies resolve within the package root.
  *
- * Only checks dependencies with a `path` field and no `url`/`git` field
- * (those are subdirectories within a remote repo, not local filesystem paths).
+ * Checks dependencies with a `base` or `path` field (base is modern post-migration, path is legacy)
+ * and no `url`/`git` field (those are subdirectories within a remote repo, not local filesystem paths).
  *
  * @param manifest - Parsed openpackage.yml
  * @param packageRoot - Absolute path to the package root directory
@@ -48,17 +48,21 @@ export function validateDependencyContainment(
   ];
 
   for (const dep of allDeps) {
-    // Only check local path deps (no url/git)
-    if (!dep.path || dep.url || dep.git) continue;
+    // Only check local path deps (no url/git).
+    // base is the modern field (post-migration), path is legacy (pre-migration).
+    // Either indicates a local source that must be validated for containment.
+    if ((!dep.base && !dep.path) || dep.url || dep.git) continue;
 
-    const { absolute: resolvedAbs } = resolveDeclaredPath(dep.path, packageRoot);
+    // Prefer base (modern) over path (legacy fallback for old manifests)
+    const pathToValidate = dep.base ?? dep.path!;
+    const { absolute: resolvedAbs } = resolveDeclaredPath(pathToValidate, packageRoot);
     const relative = path.relative(packageRoot, resolvedAbs);
 
     // Violation: path escapes the package root (starts with '..')
     if (relative.startsWith('..') || path.isAbsolute(relative)) {
       violations.push({
         name: dep.name,
-        declaredPath: dep.path,
+        declaredPath: pathToValidate,
         resolvedPath: resolvedAbs,
         reason: relative.startsWith('..') ? 'escapes-root' : 'absolute-external',
       });

--- a/packages/core/src/utils/validation/dependency-containment.ts
+++ b/packages/core/src/utils/validation/dependency-containment.ts
@@ -48,12 +48,9 @@ export function validateDependencyContainment(
   ];
 
   for (const dep of allDeps) {
-    // Only check local path deps (no url/git).
-    // base is the modern field (post-migration), path is legacy (pre-migration).
-    // Either indicates a local source that must be validated for containment.
+    // Only check local path deps (no url/git)
     if ((!dep.base && !dep.path) || dep.url || dep.git) continue;
 
-    // Prefer base (modern) over path (legacy fallback for old manifests)
     const pathToValidate = dep.base ?? dep.path!;
     const { absolute: resolvedAbs } = resolveDeclaredPath(pathToValidate, packageRoot);
     const relative = path.relative(packageRoot, resolvedAbs);


### PR DESCRIPTION
## Summary

Fixed three bugs where code was reading `dep.path` after the `parsePackageYml` migration had already moved it to `dep.base` for local source dependencies.

## Changes

### 1. dependency-graph.ts (Bug #1 - HIGH priority)
- Updated shadow `PackageDependency` interface to include `base` field
- Modified `resolveFromManifest()` to check `dep.base || dep.path` (modern field first, legacy fallback)
- **Fixes the failing test**: `tests/core/source-resolution/source-resolution.test.ts` where transitive dependencies with local paths were falling through to registry lookup

### 2. dependency-containment.ts (Bug #2 - MEDIUM priority)
- Updated validation to include `dep.base` in containment checks
- Previously only checked `dep.path`, so dependencies migrated to `dep.base` were silently skipped
- This was a **publish-time safety gap** where a package with an escaping `base` path could have been published

### 3. package-management.ts (Bug #3 - LOW priority)
- Changed GitHub name matching from `dep.path` to `dep.base` when extracting git source paths
- For git sources, `base` is the subdirectory within the repo (post-migration); `path` is for resource selection
- Fallback to deprecated `subdirectory` field for backward compatibility

## Test Results

- ✅ `tests/core/source-resolution/source-resolution.test.ts` now passes
- ✅ Build succeeds
- ℹ️ Pre-existing failures in `tests/core/add/add-flow-based-mapping.test.ts` are unrelated

## Migration Context

The `parsePackageYml` function performs semantic field migration for local source dependencies:
- Renames `dep.path` → `dep.base` (separates source navigation from resource selection)
- Deletes the old `path` field, so downstream code must read from `base`

These fixes ensure all three resolution/validation paths handle the migrated field correctly.