### PR TITLE
Fix out-of-workspace platform file mapping in add command

### DIFF
--- a/packages/core/src/core/platform/platform-mapper.ts
+++ b/packages/core/src/core/platform/platform-mapper.ts
@@ -402,17 +402,30 @@ function extractPlatformSuffix(absolutePath: string): string | null {
   const allFromPatterns = getNonFallbackFromPatterns();
   if (allFromPatterns.length === 0) return null;
 
-  // Try suffixes from shortest (just filename) to longer, looking for a match
+  // Try suffixes from shortest (just filename) to longer, looking for a match.
+  // Prefer suffixes whose first component is a known platform root directory
+  // (e.g. .claude/, .cursor/). Shorter suffixes may match permissive patterns
+  // like **/skills/**/* or skills/**/* that lose platform directory context,
+  // causing incorrect platform selection and path duplication downstream.
+  const dirLookup = getPlatformDirLookup();
+  let firstMatch: string | null = null;
+
   for (let i = segments.length - 1; i >= 0; i--) {
     const suffix = segments.slice(i).join('/');
     for (const pattern of allFromPatterns) {
       if (matchesFlowPattern(suffix, pattern)) {
-        return suffix;
+        if (!firstMatch) firstMatch = suffix;
+        // If this suffix starts with a known platform root dir, it's the
+        // most specific match — return immediately.
+        const firstComponent = suffix.split('/')[0];
+        if (dirLookup[firstComponent]) {
+          return suffix;
+        }
       }
     }
   }
 
-  return null;
+  return firstMatch;
 }
 
 /**

--- a/packages/core/src/core/platform/platform-mapper.ts
+++ b/packages/core/src/core/platform/platform-mapper.ts
@@ -402,7 +402,6 @@ function extractPlatformSuffix(absolutePath: string): string | null {
   const allFromPatterns = getNonFallbackFromPatterns();
   if (allFromPatterns.length === 0) return null;
 
-  // Try suffixes from shortest (just filename) to longer, looking for a match.
   // Prefer suffixes whose first component is a known platform root directory
   // (e.g. .claude/, .cursor/). Shorter suffixes may match permissive patterns
   // like **/skills/**/* or skills/**/* that lose platform directory context,
@@ -415,10 +414,7 @@ function extractPlatformSuffix(absolutePath: string): string | null {
     for (const pattern of allFromPatterns) {
       if (matchesFlowPattern(suffix, pattern)) {
         if (!firstMatch) firstMatch = suffix;
-        // If this suffix starts with a known platform root dir, it's the
-        // most specific match — return immediately.
-        const firstComponent = suffix.split('/')[0];
-        if (dirLookup[firstComponent]) {
+        if (dirLookup[segments[i]]) {
           return suffix;
         }
       }


### PR DESCRIPTION
## Summary

Fixed `extractPlatformSuffix` returning the wrong path suffix for out-of-workspace files, causing incorrect platform selection and doubled path segments.

## Root Cause

When adding an external file like `/tmp/ext/.claude/skills/commits/SKILL.md`, `extractPlatformSuffix` walks path suffixes shortest-to-longest:

1. `SKILL.md` → no match
2. `commits/SKILL.md` → no match
3. `skills/commits/SKILL.md` → matches `**/skills/**/*` (claude-plugin) AND `skills/**/*` (openclaw). **Returned immediately** — never reaches step 4.
4. `.claude/skills/commits/SKILL.md` → would match `.claude/skills/**/*` (claude) ← correct match, never reached

The short suffix `skills/commits/SKILL.md` caused:
- Wrong platform selected (`claude-plugin` instead of `claude`)
- `mapPathUsingFlowPattern` with empty `fromBase` returned `skills/commits/SKILL.md` as `relPath`
- Combined with `subdir = "skills"` → **`skills/skills/commits/SKILL.md`** (doubled)
- File placed at wrong location; test assertions failed

## Fix

Modified `extractPlatformSuffix` to prefer suffixes whose first component is a **known platform root directory** (`.claude`, `.cursor`, `.cline`, etc.) via the existing `getPlatformDirLookup()`. Shorter matches without a platform dir prefix are saved as fallback.

For the example above:
- `skills/commits/SKILL.md` matches but `skills` is not a platform dir → saved as fallback
- `.claude/skills/commits/SKILL.md` matches and `.claude` IS a platform dir → **returned immediately**

Downstream, the correct claude platform is selected, `fromBase = '.claude/skills'` properly strips the prefix, producing `relPath = 'commits/SKILL.md'`, and the final path is `skills/commits/SKILL.md` (correct).

## Test Results

- ✅ `tests/core/add/add-flow-based-mapping.test.ts` — all 12 tests pass (2 previously failing)
- ✅ Full test suite — zero regressions (only pre-existing `source-resolution.test.ts` failure from separate path→base migration issue, fixed in #49)