### PR TITLE
Fix root/ files under dot-prefixed dirs not installed from GitHub URLs

### DIFF
--- a/packages/core/src/core/flows/import-pipeline.ts
+++ b/packages/core/src/core/flows/import-pipeline.ts
@@ -18,9 +18,9 @@ import { getApplicableFlows } from '../install/strategies/helpers/flow-helpers.j
 import { discoverFlowSources } from './flow-source-discovery.js';
 import { executeFlowsForSources } from './flow-execution-coordinator.js';
 import { filterSourcesByPlatform } from '../install/strategies/helpers/platform-filtering.js';
-import { minimatch } from 'minimatch';
 import { relative } from 'path';
 import { deriveResourceLeafFromPackageName } from '../../utils/plugin-naming.js';
+import { matchPackagePath } from '../../utils/match-path.js';
 
 // ---------------------------------------------------------------------------
 // Types
@@ -224,7 +224,7 @@ export function applyResourceFiltering(
         isAbs ? relative(packageRoot, sourcePath) : normalizedSource
       ).replace(/\\/g, '/');
 
-      return minimatch(relativePath, normalizedPattern);
+      return matchPackagePath(relativePath, normalizedPattern);
     });
 
     if (filtered.length > 0) {

--- a/packages/core/src/core/install/helpers/file-discovery.ts
+++ b/packages/core/src/core/install/helpers/file-discovery.ts
@@ -4,10 +4,10 @@ import type { PackageFile } from '../../../types/index.js';
 import type { Platform } from '../../platforms.js';
 import { isManifestPath, normalizePackagePath } from '../../../utils/manifest-paths.js';
 import { getPlatformRootFileNames } from '../../platform/platform-root-files.js';
-import { minimatch } from 'minimatch';
 import { join } from 'path';
 import { exists } from '../../../utils/fs.js';
 import { hasPluginContent } from '../plugin-detector.js';
+import { matchPackagePath } from '../../../utils/match-path.js';
 
 export interface CategorizedInstallFiles {
   pathBasedFiles: PackageFile[];
@@ -45,7 +45,7 @@ export async function discoverAndCategorizeFiles(
   // Phase 4: Build include filter that considers matchedPattern
   const shouldInclude = (path: string): boolean => {
     // Check matched pattern (from base detection or resource scoping)
-    if (matchedPattern && !minimatch(path, matchedPattern)) {
+    if (matchedPattern && !matchPackagePath(path, matchedPattern)) {
       return false;
     }
     

--- a/packages/core/src/core/install/unified/phases/convert.ts
+++ b/packages/core/src/core/install/unified/phases/convert.ts
@@ -15,9 +15,9 @@ import { readdir } from 'fs/promises';
 import { join } from 'path';
 import { readFile } from 'fs/promises';
 import type { PackageFile as DetectionPackageFile } from '../../detection-types.js';
-import { minimatch } from 'minimatch';
 import { getPlatformDefinitions, matchesUniversalPattern } from '../../../platforms.js';
 import { getPatternFromFlow } from '../../schema-registry.js';
+import { matchPackagePath } from '../../../../utils/match-path.js';
 import { getRelativePathFromBase } from '../../../../utils/path-normalization.js';
 import { 
   createTempPackageDirectory, 
@@ -226,7 +226,7 @@ async function loadPackageFiles(
   
   function isRelevantPath(relPath: string, targetDir: string, matchedPattern?: string): boolean {
     const normalized = relPath.replace(/\\/g, '/').replace(/^\.\/?/, '');
-    const matchesMatchedPattern = matchedPattern ? minimatch(normalized, matchedPattern) : true;
+    const matchesMatchedPattern = matchedPattern ? matchPackagePath(normalized, matchedPattern) : true;
     if (!matchesMatchedPattern) {
       return false;
     }
@@ -241,7 +241,7 @@ async function loadPackageFiles(
         const importFlows = def.import || [];
         for (const flow of importFlows) {
           const pattern = getPatternFromFlow(flow as any, 'from');
-          if (pattern && minimatch(normalized, pattern)) {
+          if (pattern && matchPackagePath(normalized, pattern)) {
             importMatch = { platformId, pattern };
             break;
           }

--- a/packages/core/src/utils/match-path.ts
+++ b/packages/core/src/utils/match-path.ts
@@ -1,0 +1,13 @@
+import { minimatch } from 'minimatch';
+
+/**
+ * Match a package-relative path against a glob pattern.
+ *
+ * Always enables `dot: true` so that paths containing dot-prefixed segments
+ * (e.g. `.opencode/`, `.claude/`) are matched correctly. Without this,
+ * `minimatch("root/.opencode/hooks.ts", "**")` returns false — silently
+ * dropping files that live under dot-prefixed directories.
+ */
+export function matchPackagePath(path: string, pattern: string): boolean {
+  return minimatch(path, pattern, { dot: true });
+}


### PR DESCRIPTION
## Summary

- Fixes #43 — `root/` directory files containing dot-prefixed path segments (e.g. `root/.opencode/plugins/qmd-hooks.ts`) were silently skipped when installing from a GitHub URL, but worked from local paths
- Root cause: `minimatch(path, "**")` returns `false` for paths with dot-prefixed segments (like `.opencode/`) unless `{dot: true}` is passed. GitHub installs set `matchedPattern = "**"` via `computePathScoping`; local installs never set it, so the filter was inactive
- Introduces a centralized `matchPackagePath` utility that wraps `minimatch` with `{dot: true}` and replaces bare `minimatch()` at all 4 affected call sites