### PR TITLE
feat: add rules mapping for OpenCode platform

### DIFF
--- a/platforms.jsonc
+++ b/platforms.jsonc
@@ -1444,6 +1444,18 @@
     "detection": [".opencode"],
     "export": [
       {
+        "from": "rules/**/*.md",
+        "to": {
+          "$switch": {
+            "field": "$$targetRoot",
+            "cases": [
+              { "pattern": "~/", "value": ".config/opencode/rules/**/*.md" }
+            ],
+            "default": ".opencode/rules/**/*.md"
+          }
+        }
+      },
+      {
         "from": "commands/**/*.md",
         "to": {
           "$switch": {
@@ -1525,6 +1537,18 @@
       { "from": "root/**/*", "to": "**/*", "fallback": true, "comment": "Catch-all: install root-stored files to workspace root" }
     ],
     "import": [
+      {
+        "from": {
+          "$switch": {
+            "field": "$$targetRoot",
+            "cases": [
+              { "pattern": "~/", "value": ".config/opencode/rules/**/*.md" }
+            ],
+            "default": ".opencode/rules/**/*.md"
+          }
+        },
+        "to": "rules/**/*.md"
+      },
       {
         "from": {
           "$switch": {


### PR DESCRIPTION
## Summary

- Adds missing `rules/**/*.md` export and import entries to the OpenCode platform definition in `platforms.jsonc`
- Rules now install to `.opencode/rules/` (workspace) or `.config/opencode/rules/` (global), consistent with other platforms

Fixes #55