### PR TITLE
fix: preserve executable file permissions during install

### DIFF
--- a/packages/core/src/core/flows/flow-executor.ts
+++ b/packages/core/src/core/flows/flow-executor.ts
@@ -762,6 +762,16 @@ export class DefaultFlowExecutor implements FlowExecutor {
 
         await fsUtils.ensureDir(path.dirname(targetPath));
         await fs.writeFile(targetPath, content);
+
+        // Preserve executable permission from source file
+        try {
+          const sourceStat = await fs.stat(sourcePath);
+          if (sourceStat.mode & 0o111) {
+            await fs.chmod(targetPath, sourceStat.mode);
+          }
+        } catch {
+          // Ignore permission preservation failures
+        }
       }
 
       return {

--- a/packages/core/src/utils/git-url-detection.ts
+++ b/packages/core/src/utils/git-url-detection.ts
@@ -383,12 +383,15 @@ function parseHashFragment(
  * - Ends with .git extension
  */
 export function isGitUrl(input: string): boolean {
+  // Strip hash fragment for .git extension check (e.g., repo.git#ref)
+  const baseUrl = input.split('#', 1)[0];
   return (
     input.startsWith('https://') ||
     input.startsWith('http://') ||
     input.startsWith('git://') ||
+    input.startsWith('ssh://') ||
     input.startsWith('git@') ||
-    input.endsWith('.git')
+    baseUrl.endsWith('.git')
   );
 }
 

--- a/platforms.jsonc
+++ b/platforms.jsonc
@@ -1444,6 +1444,18 @@
     "detection": [".opencode"],
     "export": [
       {
+        "from": "rules/**/*.md",
+        "to": {
+          "$switch": {
+            "field": "$$targetRoot",
+            "cases": [
+              { "pattern": "~/", "value": ".config/opencode/rules/**/*.md" }
+            ],
+            "default": ".opencode/rules/**/*.md"
+          }
+        }
+      },
+      {
         "from": "commands/**/*.md",
         "to": {
           "$switch": {
@@ -1525,6 +1537,18 @@
       { "from": "root/**/*", "to": "**/*", "fallback": true, "comment": "Catch-all: install root-stored files to workspace root" }
     ],
     "import": [
+      {
+        "from": {
+          "$switch": {
+            "field": "$$targetRoot",
+            "cases": [
+              { "pattern": "~/", "value": ".config/opencode/rules/**/*.md" }
+            ],
+            "default": ".opencode/rules/**/*.md"
+          }
+        },
+        "to": "rules/**/*.md"
+      },
       {
         "from": {
           "$switch": {


### PR DESCRIPTION
## Summary

- Preserve file execute permissions when copying files during install
- After writing a file, check if the source has any execute bits set and apply the same mode to the target

Fixes #59