### PR TITLE
Fix: Codex agent installation flow

### DIFF
--- a/README.md
+++ b/README.md
@@ -226,7 +226,7 @@ OpenPackage performs installation and platform sync of files for supported AI co
 | Claude Code Plugin | .claude-plugin/ | | rules/ | commands/ | agents/ | skills/ | .mcp.json (root) |
 | Cline | .cline/ | | | | | skills/ | cline_mcp_settings.json |
 | CodeBuddy | .codebuddy/ | | rules/ | | | skills/ | |
-| Codex CLI | .codex/ | | | prompts/ | | skills/ | config.toml |
+| Codex CLI | .codex/ | | | prompts/ | agents/ | skills/ | config.toml |
 | Command Code | .commandcode/ | | | commands/ | agents/ | skills/ | |
 | Continue | .continue/ | | rules/ | prompts/ | | skills/ | |
 | Crush | .config/crush/ | | | | | skills/ | crush.json (root) |

--- a/packages/core/src/core/add/add-conflict-handler.ts
+++ b/packages/core/src/core/add/add-conflict-handler.ts
@@ -1,6 +1,7 @@
 import { basename, dirname, extname, join, relative as pathRelative } from 'path';
 
 import yaml from 'js-yaml';
+import * as TOML from 'smol-toml';
 import { parse as parseJsonc } from 'jsonc-parser';
 
 import type { PackageFile } from '../../types/index.js';
@@ -71,6 +72,8 @@ function parseStructuredContent(raw: string, ext: string): any | null {
       case '.yaml':
       case '.yml':
         return yaml.load(raw) ?? null;
+      case '.toml':
+        return TOML.parse(raw);
       default:
         return null;
     }
@@ -91,6 +94,12 @@ function serializeStructuredContent(data: any, ext: string): string {
     case '.yaml':
     case '.yml':
       return yaml.dump(data, { indent: 2, flowLevel: -1, lineWidth: -1, noRefs: true });
+    case '.toml':
+      return TOML.stringify(data);
+    case '.md':
+    case '.mdc':
+    case '.markdown':
+      return serializeMarkdownDocument(data);
     default:
       return JSON.stringify(data, null, 2) + '\n';
   }

--- a/packages/core/src/core/flows/flow-executor.ts
+++ b/packages/core/src/core/flows/flow-executor.ts
@@ -526,20 +526,23 @@ export class DefaultFlowExecutor implements FlowExecutor {
             path: path.relative(context.packageRoot, sourcePath),
             ext: path.extname(sourcePath),
           });
-          
-          // For markdown files, apply to frontmatter
-          if (data && typeof data === 'object' && 'frontmatter' in data) {
+
+          // Auto-split frontmatter only for .md → .md flows. For .md → structured
+          // (toml/json/yaml/etc.), the user's pipeline must reshape both halves
+          // into a single flat object, so pass the whole document.
+          const targetFormat = this.detectFormat(targetPath, '');
+          const isMarkdownTarget = targetFormat === 'markdown' || targetFormat === 'md';
+          if (data && typeof data === 'object' && 'frontmatter' in data && isMarkdownTarget) {
             data.frontmatter = applyMapPipeline(
-              data.frontmatter, 
-              schemaOps, 
+              data.frontmatter,
+              schemaOps,
               mapContext,
               this.transformRegistry
             );
           } else {
-            // Apply to entire document
             data = applyMapPipeline(
-              data, 
-              schemaOps, 
+              data,
+              schemaOps,
               mapContext,
               this.transformRegistry
             );
@@ -607,20 +610,21 @@ export class DefaultFlowExecutor implements FlowExecutor {
           path: path.relative(context.packageRoot, sourcePath),
           ext: path.extname(sourcePath),
         });
-        
-        // For markdown files, apply to frontmatter
-        if (data && typeof data === 'object' && 'frontmatter' in data) {
+
+        // Auto-split frontmatter only for .md → .md flows (see Step 4 comment).
+        const targetFormat = this.detectFormat(targetPath, '');
+        const isMarkdownTarget = targetFormat === 'markdown' || targetFormat === 'md';
+        if (data && typeof data === 'object' && 'frontmatter' in data && isMarkdownTarget) {
           data.frontmatter = applyMapPipeline(
-            data.frontmatter, 
-            pipeOps, 
+            data.frontmatter,
+            pipeOps,
             mapContext,
             this.transformRegistry
           );
         } else {
-          // Apply to entire document
           data = applyMapPipeline(
-            data, 
-            pipeOps, 
+            data,
+            pipeOps,
             mapContext,
             this.transformRegistry
           );

--- a/packages/core/src/core/flows/flow-transforms.ts
+++ b/packages/core/src/core/flows/flow-transforms.ts
@@ -1,15 +1,25 @@
 /**
  * Flow Transforms
- * 
+ *
  * Transform implementations for the flow execution pipeline.
- * Organized by category: Format Converters, Merge Strategies, Content Filters, 
+ * Organized by category: Format Converters, Merge Strategies, Content Filters,
  * Markdown Processors, Value Transforms, Validation.
+ *
+ * ## Naming convention
+ *
+ * - **Bidirectional primitive** (`yaml`, `toml`, `markdown`): one registration
+ *   taking a `{ direction: 'parse' | 'stringify' }` option (default `'parse'`).
+ * - **Explicit-pair aliases** (`yaml-to-json`, `json-to-yaml`): thin wrappers
+ *   that pre-set the direction.
+ *
+ * `$pipe` arrays accept bare names only (`pipe.ts` doesn't pass options), so
+ * flow authors should always use the explicit-pair name in `platforms.jsonc`.
  */
 
 import yaml from 'js-yaml';
 import * as TOML from 'smol-toml';
 import { logger } from '../../utils/logger.js';
-import { serializeMarkdownDocument } from './markdown.js';
+import { parseMarkdownDocument, serializeMarkdownDocument } from './markdown.js';
 
 /**
  * Transform function interface
@@ -100,7 +110,13 @@ export const jsoncTransform: Transform = {
 };
 
 /**
- * Convert between YAML and object
+ * Convert between YAML and object.
+ *
+ * Bidirectional primitive — flow authors should prefer the explicit-pair
+ * aliases at `$pipe` call sites.
+ *
+ * @see jsonToYamlTransform
+ * @see yamlToJsonTransform
  */
 export const yamlTransform: Transform = {
   name: 'yaml',
@@ -125,9 +141,15 @@ export const yamlTransform: Transform = {
 };
 
 /**
- * Convert between TOML and object
- * 
+ * Convert between TOML and object.
+ *
  * Uses smol-toml for TOML v1.0.0 compliant serialization and parsing.
+ *
+ * Bidirectional primitive — flow authors should prefer the explicit-pair
+ * aliases at `$pipe` call sites.
+ *
+ * @see jsonToTomlTransform
+ * @see tomlToJsonTransform
  */
 export const tomlTransform: Transform = {
   name: 'toml',
@@ -171,6 +193,26 @@ export const tomlToJsonTransform: Transform = {
   name: 'toml-to-json',
   execute(input: string): any {
     return tomlTransform.execute(input, { direction: 'parse' });
+  },
+};
+
+/**
+ * Convert JSON object to YAML string.
+ */
+export const jsonToYamlTransform: Transform = {
+  name: 'json-to-yaml',
+  execute(input: any): string {
+    return yamlTransform.execute(input, { direction: 'stringify' });
+  },
+};
+
+/**
+ * Convert YAML string to JSON object.
+ */
+export const yamlToJsonTransform: Transform = {
+  name: 'yaml-to-json',
+  execute(input: string): any {
+    return yamlTransform.execute(input, { direction: 'parse' });
   },
 };
 
@@ -305,6 +347,55 @@ export const sectionsTransform: Transform = {
     }
 
     return sections;
+  },
+};
+
+/**
+ * Convert between Markdown (with optional YAML frontmatter) and a structured
+ * `{ frontmatter?, body }` object.
+ *
+ * Bidirectional primitive — flow authors should prefer the explicit-pair
+ * aliases at `$pipe` call sites.
+ *
+ * Strict-by-default on invalid YAML frontmatter (parse direction throws).
+ * This differs from {@link frontmatterTransform}, which silently returns
+ * `{}` on parse failure — that helper is for inline extraction in
+ * sub-pipelines, not for full document round-trips.
+ *
+ * @see jsonToMarkdownTransform
+ * @see markdownToJsonTransform
+ */
+export const markdownTransform: Transform = {
+  name: 'markdown',
+  execute(input: any, options?: { direction?: 'parse' | 'stringify' }): any {
+    const direction = options?.direction || 'parse';
+    if (direction === 'parse') {
+      if (typeof input !== 'string') {
+        return input;
+      }
+      return parseMarkdownDocument(input);
+    }
+    return serializeMarkdownDocument(input);
+  },
+};
+
+/**
+ * Parse Markdown to a `{ frontmatter?, body }` object.
+ */
+export const markdownToJsonTransform: Transform = {
+  name: 'markdown-to-json',
+  execute(input: string): any {
+    return markdownTransform.execute(input, { direction: 'parse' });
+  },
+};
+
+/**
+ * Serialize a `{ frontmatter?, body }` object back to Markdown.
+ */
+export const jsonToMarkdownTransform: Transform = {
+  name: 'json-to-markdown',
+  execute(input: any): string {
+    return markdownTransform.execute(input, { direction: 'stringify' });
   },
 };
 
@@ -662,6 +753,8 @@ export function createDefaultTransformRegistry(): TransformRegistry {
   registry.register(tomlTransform);
   registry.register(jsonToTomlTransform);
   registry.register(tomlToJsonTransform);
+  registry.register(jsonToYamlTransform);
+  registry.register(yamlToJsonTransform);
 
   // Content filters
   registry.register(filterCommentsTransform);
@@ -670,6 +763,9 @@ export function createDefaultTransformRegistry(): TransformRegistry {
 
   // Markdown transforms
   registry.register(sectionsTransform);
+  registry.register(markdownTransform);
+  registry.register(markdownToJsonTransform);
+  registry.register(jsonToMarkdownTransform);
   registry.register(frontmatterTransform);
   registry.register(bodyTransform);
 

--- a/platforms.jsonc
+++ b/platforms.jsonc
@@ -680,8 +680,34 @@
         "to": ".agents/skills/{resourceLeaf}/assets/**/*"
       },
       {
-        "from": "agents/**/*",
-        "to": ".agents/skills/{resourceLeaf}/agents/**/*"
+        "from": "agents/**/*.md",
+        "to": ".codex/agents/**/*.toml",
+        "map": [
+          { "$pipe": ["markdown-to-json"] },
+          // Default `name` from filename (universal agent format has no `name`
+          // in frontmatter); frontmatter.name overrides via the rename below.
+          { "$set": { "name": "$$filename" } },
+          { "$pipeline": {
+            "field": "name",
+            "operations": [
+              { "$replace": { "pattern": "\\.md$", "with": "" } }
+            ]
+          }},
+          // Lift body to developer_instructions; lift any frontmatter fields
+          // to top level. $rename is no-op on missing source.
+          { "$rename": {
+            "body": "developer_instructions",
+            "frontmatter.name": "name",
+            "frontmatter.description": "description",
+            "frontmatter.model": "model",
+            "frontmatter.model_reasoning_effort": "model_reasoning_effort",
+            "frontmatter.sandbox_mode": "sandbox_mode",
+            "frontmatter.mcp_servers": "mcp_servers"
+          }},
+          { "$unset": "frontmatter" },
+          { "$pipe": ["json-to-toml"] }
+        ],
+        "description": "Universal agents → Codex subagents (.codex/agents/*.toml; targetDir routes project vs ~/)"
       },
       {
         "from": "commands/**/*",
@@ -769,6 +795,24 @@
       {
         "from": ".agents/skills/**/*",
         "to": "skills/**/*"
+      },
+      {
+        "from": ".codex/agents/**/*.toml",
+        "to": "agents/**/*.md",
+        "map": [
+          { "$pipe": ["toml-to-json"] },
+          { "$rename": {
+            "developer_instructions": "body",
+            "name": "frontmatter.name",
+            "description": "frontmatter.description",
+            "model": "frontmatter.model",
+            "model_reasoning_effort": "frontmatter.model_reasoning_effort",
+            "sandbox_mode": "frontmatter.sandbox_mode",
+            "mcp_servers": "frontmatter.mcp_servers"
+          }},
+          { "$pipe": ["json-to-markdown"] }
+        ],
+        "description": "Codex subagents (.codex/agents/*.toml) → universal agents/*.md"
       },
       {
         "from": ".codex/config.toml",

--- a/platforms.jsonc
+++ b/platforms.jsonc
@@ -710,10 +710,6 @@
         "description": "Universal agents → Codex subagents (.codex/agents/*.toml; targetDir routes project vs ~/)"
       },
       {
-        "from": "commands/**/*",
-        "to": ".agents/skills/{resourceLeaf}/commands/**/*"
-      },
-      {
         "from": ["README.md", "EXAMPLES.md"],
         "to": ".agents/skills/{resourceLeaf}/references/*"
       },

--- a/platforms.jsonc
+++ b/platforms.jsonc
@@ -660,26 +660,6 @@
         "to": ".agents/skills/**/*"
       },
       {
-        "from": "SKILL.md",
-        "to": ".agents/skills/{resourceLeaf}/SKILL.md"
-      },
-      {
-        "from": "references/**/*",
-        "to": ".agents/skills/{resourceLeaf}/references/**/*"
-      },
-      {
-        "from": "reference/**/*",
-        "to": ".agents/skills/{resourceLeaf}/references/**/*"
-      },
-      {
-        "from": "scripts/**/*",
-        "to": ".agents/skills/{resourceLeaf}/scripts/**/*"
-      },
-      {
-        "from": "assets/**/*",
-        "to": ".agents/skills/{resourceLeaf}/assets/**/*"
-      },
-      {
         "from": "agents/**/*.md",
         "to": ".codex/agents/**/*.toml",
         "map": [
@@ -708,10 +688,6 @@
           { "$pipe": ["json-to-toml"] }
         ],
         "description": "Universal agents → Codex subagents (.codex/agents/*.toml; targetDir routes project vs ~/)"
-      },
-      {
-        "from": ["README.md", "EXAMPLES.md"],
-        "to": ".agents/skills/{resourceLeaf}/references/*"
       },
       {
         "from": ["mcp.jsonc", "mcp.json"],

--- a/tests/core/flows/transforms/markdown-transforms.test.ts
+++ b/tests/core/flows/transforms/markdown-transforms.test.ts
@@ -1,0 +1,118 @@
+import assert from 'node:assert/strict';
+import { describe, it } from 'node:test';
+import {
+  markdownTransform,
+  markdownToJsonTransform,
+  jsonToMarkdownTransform,
+  createDefaultTransformRegistry,
+} from '../../../../packages/core/src/core/flows/flow-transforms.js';
+
+describe('Markdown Transforms', () => {
+  describe('markdown transform — parse direction', () => {
+    it('parses Markdown with YAML frontmatter into { frontmatter, body }', () => {
+      const input = '---\nname: code-reviewer\nmodel: opus\n---\n\nReview code.';
+      const result = markdownTransform.execute(input, { direction: 'parse' });
+
+      assert.deepEqual(result.frontmatter, { name: 'code-reviewer', model: 'opus' });
+      assert.equal(result.body, 'Review code.');
+    });
+
+    it('returns { body } with no frontmatter key for body-only Markdown', () => {
+      const input = 'Just a body, no frontmatter.';
+      const result = markdownTransform.execute(input, { direction: 'parse' });
+
+      assert.equal(result.body, 'Just a body, no frontmatter.');
+      assert.equal('frontmatter' in result, false);
+    });
+
+    it('defaults to parse direction when no options given', () => {
+      const input = '---\nkey: value\n---\n\nbody';
+      const result = markdownTransform.execute(input);
+
+      assert.deepEqual(result.frontmatter, { key: 'value' });
+      assert.equal(result.body, 'body');
+    });
+
+    it('passes non-string input through unchanged', () => {
+      const input = { already: 'an object' };
+      const result = markdownTransform.execute(input, { direction: 'parse' });
+      assert.equal(result, input);
+    });
+  });
+
+  describe('markdown transform — stringify direction', () => {
+    it('serializes { frontmatter, body } to Markdown', () => {
+      const input = { frontmatter: { name: 'agent', model: 'opus' }, body: 'Body here.' };
+      const result = markdownTransform.execute(input, { direction: 'stringify' });
+
+      assert.equal(typeof result, 'string');
+      assert.ok(result.startsWith('---\n'));
+      assert.ok(result.includes('name: agent'));
+      assert.ok(result.includes('model: opus'));
+      assert.ok(result.endsWith('Body here.'));
+    });
+
+    it('passes string input through unchanged', () => {
+      const input = 'already a string';
+      const result = markdownTransform.execute(input, { direction: 'stringify' });
+      assert.equal(result, input);
+    });
+  });
+
+  describe('round-trip', () => {
+    it('preserves frontmatter (deep-equal) and body (whitespace-tolerant)', () => {
+      const original = {
+        frontmatter: { name: 'agent', description: 'Reviews code', tags: ['review', 'qa'] },
+        body: 'This is the agent body.\n\nSecond paragraph.',
+      };
+
+      const stringified = markdownTransform.execute(original, { direction: 'stringify' });
+      const reparsed = markdownTransform.execute(stringified, { direction: 'parse' });
+
+      assert.deepEqual(reparsed.frontmatter, original.frontmatter);
+      assert.equal(reparsed.body.trim(), original.body.trim());
+    });
+
+    it('is byte-exact for body-only inputs', () => {
+      const original = 'plain markdown without frontmatter';
+      const parsed = markdownTransform.execute(original, { direction: 'parse' });
+      const restringified = markdownTransform.execute(parsed, { direction: 'stringify' });
+      assert.equal(restringified, original);
+    });
+  });
+
+  describe('alias delegation', () => {
+    it('markdown-to-json delegates to markdown { direction: parse }', () => {
+      const input = '---\nname: x\n---\n\nbody';
+      assert.deepEqual(
+        markdownToJsonTransform.execute(input),
+        markdownTransform.execute(input, { direction: 'parse' }),
+      );
+    });
+
+    it('json-to-markdown delegates to markdown { direction: stringify }', () => {
+      const input = { frontmatter: { name: 'x' }, body: 'body' };
+      assert.equal(
+        jsonToMarkdownTransform.execute(input),
+        markdownTransform.execute(input, { direction: 'stringify' }),
+      );
+    });
+  });
+
+  describe('registry registration', () => {
+    it('registers markdown, markdown-to-json, json-to-markdown', () => {
+      const registry = createDefaultTransformRegistry();
+      assert.ok(registry.has('markdown'), 'markdown should be registered');
+      assert.ok(registry.has('markdown-to-json'), 'markdown-to-json should be registered');
+      assert.ok(registry.has('json-to-markdown'), 'json-to-markdown should be registered');
+    });
+
+    it('runs end-to-end via the registry execute path', () => {
+      const registry = createDefaultTransformRegistry();
+      const input = '---\nname: registered\n---\n\nbody';
+      const result = registry.execute('markdown-to-json', input);
+      assert.deepEqual(result.frontmatter, { name: 'registered' });
+      assert.equal(result.body, 'body');
+    });
+  });
+});

--- a/tests/core/flows/transforms/yaml-aliases.test.ts
+++ b/tests/core/flows/transforms/yaml-aliases.test.ts
@@ -1,0 +1,95 @@
+/**
+ * YAML Alias Transform Tests
+ *
+ * Regression coverage for `yaml-to-json` and `json-to-yaml` aliases.
+ * Both aliases are referenced by the bundled Goose flows (platforms.jsonc
+ * around the Goose MCP install/import) and were previously unregistered,
+ * causing `Transform not found` crashes at install time.
+ */
+
+import assert from 'node:assert/strict';
+import { describe, it } from 'node:test';
+import yaml from 'js-yaml';
+import {
+  yamlTransform,
+  yamlToJsonTransform,
+  jsonToYamlTransform,
+  createDefaultTransformRegistry,
+} from '../../../../packages/core/src/core/flows/flow-transforms.js';
+
+describe('YAML alias transforms', () => {
+  describe('registry registration', () => {
+    it('registers yaml-to-json and json-to-yaml', () => {
+      const registry = createDefaultTransformRegistry();
+      assert.ok(registry.has('yaml-to-json'), 'yaml-to-json should be registered');
+      assert.ok(registry.has('json-to-yaml'), 'json-to-yaml should be registered');
+    });
+  });
+
+  describe('alias delegation', () => {
+    it('yaml-to-json delegates to yaml { direction: parse }', () => {
+      const input = 'name: foo\nmodel: bar';
+      assert.deepEqual(
+        yamlToJsonTransform.execute(input),
+        yamlTransform.execute(input, { direction: 'parse' }),
+      );
+    });
+
+    it('json-to-yaml delegates to yaml { direction: stringify }', () => {
+      const input = { name: 'foo', model: 'bar' };
+      assert.equal(
+        jsonToYamlTransform.execute(input),
+        yamlTransform.execute(input, { direction: 'stringify' }),
+      );
+    });
+  });
+
+  describe('Goose-shape regression', () => {
+    // Mirrors the shape produced by platforms.jsonc Goose flows after
+    // the $rename step — `mcpServers` already renamed to `extensions`.
+    const gooseShape = {
+      extensions: {
+        github: {
+          command: 'npx',
+          args: ['-y', '@modelcontextprotocol/server-github'],
+          env: { GITHUB_TOKEN: 'placeholder' },
+        },
+        sqlite: {
+          command: 'uvx',
+          args: ['mcp-server-sqlite', '--db-path', './test.db'],
+        },
+      },
+    };
+
+    it('round-trips through json-to-yaml then yaml-to-json without loss', () => {
+      const yamlString = jsonToYamlTransform.execute(gooseShape);
+      assert.equal(typeof yamlString, 'string');
+      assert.ok(yamlString.includes('extensions:'));
+      assert.ok(yamlString.includes('github:'));
+
+      const reparsed = yamlToJsonTransform.execute(yamlString);
+      assert.deepEqual(reparsed, gooseShape);
+    });
+
+    it('produces valid YAML that js-yaml can parse independently', () => {
+      const yamlString = jsonToYamlTransform.execute(gooseShape);
+      const parsed = yaml.load(yamlString);
+      assert.deepEqual(parsed, gooseShape);
+    });
+  });
+
+  describe('end-to-end via registry execute path', () => {
+    it('runs json-to-yaml through the registry like a $pipe call would', () => {
+      const registry = createDefaultTransformRegistry();
+      const result = registry.execute('json-to-yaml', { hello: 'world' });
+      assert.equal(typeof result, 'string');
+      assert.ok(result.includes('hello: world'));
+    });
+
+    it('runs yaml-to-json through the registry like a $pipe call would', () => {
+      const registry = createDefaultTransformRegistry();
+      const result = registry.execute('yaml-to-json', 'hello: world\n');
+      assert.deepEqual(result, { hello: 'world' });
+    });
+  });
+});

--- a/tests/integration/codex-agents.test.ts
+++ b/tests/integration/codex-agents.test.ts
@@ -1,0 +1,213 @@
+/**
+ * Codex agents integration test (GH #53).
+ *
+ * Validates universal `agents/*.md` ↔ `.codex/agents/*.toml` round-trips
+ * for project scope, global scope, and frontmatter-less inputs.
+ */
+
+import assert from 'node:assert/strict';
+import { spawnSync } from 'node:child_process';
+import path from 'node:path';
+import os from 'node:os';
+import fs from 'node:fs/promises';
+import { fileURLToPath } from 'node:url';
+import { describe, it } from 'node:test';
+import * as TOML from 'smol-toml';
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = path.dirname(__filename);
+const repoRoot = path.resolve(__dirname, '../..');
+const cliPath = path.resolve(repoRoot, 'bin/openpackage');
+
+function runCli(
+  args: string[],
+  cwd: string,
+  env?: Record<string, string | undefined>,
+): { code: number; stdout: string; stderr: string } {
+  const result = spawnSync('node', [cliPath, ...args], {
+    cwd,
+    encoding: 'utf8',
+    env: {
+      ...process.env,
+      ...env,
+      TS_NODE_TRANSPILE_ONLY: '1',
+    },
+  });
+  return {
+    code: result.status ?? 1,
+    stdout: (result.stdout ?? '').trim(),
+    stderr: (result.stderr ?? '').trim(),
+  };
+}
+
+async function writeFile(filePath: string, content: string): Promise<void> {
+  await fs.mkdir(path.dirname(filePath), { recursive: true });
+  await fs.writeFile(filePath, content, 'utf8');
+}
+
+describe('codex agents integration', () => {
+  it('installs universal agents/*.md to .codex/agents/*.toml (project scope)', async () => {
+    const workspace = await fs.mkdtemp(path.join(os.tmpdir(), 'opkg-codex-agents-ws-'));
+    const sourceRoot = await fs.mkdtemp(path.join(os.tmpdir(), 'opkg-codex-agents-src-'));
+    const pkgDir = path.join(sourceRoot, 'reviewer-pkg');
+
+    try {
+      await writeFile(
+        path.join(pkgDir, 'agents', 'code-reviewer.md'),
+        '---\ndescription: Reviews code for bugs and style\nmodel: opus\n---\n\n' +
+          'You are a thorough code reviewer. Look for bugs and unclear naming.'
+      );
+
+      const result = runCli(
+        ['install', pkgDir, '--platforms', 'codex', '--force', '--conflicts', 'overwrite'],
+        workspace,
+        { CI: 'true' }
+      );
+
+      assert.equal(
+        result.code,
+        0,
+        `Install should succeed.\nstdout: ${result.stdout}\nstderr: ${result.stderr}`
+      );
+
+      const tomlPath = path.join(workspace, '.codex', 'agents', 'code-reviewer.toml');
+      const tomlContent = await fs.readFile(tomlPath, 'utf8');
+      const parsed = TOML.parse(tomlContent) as Record<string, unknown>;
+
+      assert.equal(parsed.name, 'code-reviewer', 'name should be derived from filename');
+      assert.equal(parsed.description, 'Reviews code for bugs and style');
+      assert.equal(parsed.model, 'opus');
+      assert.match(
+        parsed.developer_instructions as string,
+        /thorough code reviewer/,
+        'developer_instructions should be the markdown body'
+      );
+
+      // Misplaced flow is gone: nothing should land at .agents/skills/<leaf>/agents/
+      await assert.rejects(
+        fs.access(path.join(workspace, '.agents', 'skills', 'reviewer-pkg', 'agents', 'code-reviewer.md'))
+      );
+    } finally {
+      await fs.rm(workspace, { recursive: true, force: true });
+      await fs.rm(sourceRoot, { recursive: true, force: true });
+    }
+  });
+
+  it('installs universal agents/*.md to ~/.codex/agents/*.toml (global scope)', async () => {
+    const workspace = await fs.mkdtemp(path.join(os.tmpdir(), 'opkg-codex-agents-gws-'));
+    const sourceRoot = await fs.mkdtemp(path.join(os.tmpdir(), 'opkg-codex-agents-gsrc-'));
+    const fakeHome = await fs.mkdtemp(path.join(os.tmpdir(), 'opkg-codex-agents-home-'));
+    const pkgDir = path.join(sourceRoot, 'global-agent-pkg');
+
+    try {
+      await writeFile(
+        path.join(pkgDir, 'agents', 'planner.md'),
+        '---\ndescription: Plans multi-step tasks\n---\n\nYou are a careful planner.'
+      );
+
+      const result = runCli(
+        ['install', pkgDir, '--platforms', 'codex', '--global', '--force', '--conflicts', 'overwrite'],
+        workspace,
+        { CI: 'true', HOME: fakeHome }
+      );
+
+      assert.equal(
+        result.code,
+        0,
+        `Global install should succeed.\nstdout: ${result.stdout}\nstderr: ${result.stderr}`
+      );
+
+      const tomlPath = path.join(fakeHome, '.codex', 'agents', 'planner.toml');
+      const tomlContent = await fs.readFile(tomlPath, 'utf8');
+      const parsed = TOML.parse(tomlContent) as Record<string, unknown>;
+
+      assert.equal(parsed.name, 'planner');
+      assert.equal(parsed.description, 'Plans multi-step tasks');
+      assert.match(parsed.developer_instructions as string, /careful planner/);
+
+      // Project location should be empty for global install
+      await assert.rejects(
+        fs.access(path.join(workspace, '.codex', 'agents', 'planner.toml'))
+      );
+    } finally {
+      await fs.rm(workspace, { recursive: true, force: true });
+      await fs.rm(sourceRoot, { recursive: true, force: true });
+      await fs.rm(fakeHome, { recursive: true, force: true });
+    }
+  });
+
+  it('derives name from filename when frontmatter omits it', async () => {
+    const workspace = await fs.mkdtemp(path.join(os.tmpdir(), 'opkg-codex-agents-pl-ws-'));
+    const sourceRoot = await fs.mkdtemp(path.join(os.tmpdir(), 'opkg-codex-agents-pl-src-'));
+    const pkgDir = path.join(sourceRoot, 'plain-pkg');
+
+    try {
+      // No frontmatter — body only
+      await writeFile(
+        path.join(pkgDir, 'agents', 'plain-agent.md'),
+        'Just instructions, no frontmatter.'
+      );
+
+      const result = runCli(
+        ['install', pkgDir, '--platforms', 'codex', '--force', '--conflicts', 'overwrite'],
+        workspace,
+        { CI: 'true' }
+      );
+
+      assert.equal(result.code, 0, `Install should succeed.\nstderr: ${result.stderr}`);
+
+      const tomlPath = path.join(workspace, '.codex', 'agents', 'plain-agent.toml');
+      const tomlContent = await fs.readFile(tomlPath, 'utf8');
+      const parsed = TOML.parse(tomlContent) as Record<string, unknown>;
+
+      assert.equal(parsed.name, 'plain-agent', 'name should fall back to filename without extension');
+      assert.equal(parsed.developer_instructions, 'Just instructions, no frontmatter.');
+    } finally {
+      await fs.rm(workspace, { recursive: true, force: true });
+      await fs.rm(sourceRoot, { recursive: true, force: true });
+    }
+  });
+
+  it('round-trips .codex/agents/*.toml back to universal agents/*.md via opkg add', async () => {
+    const workspace = await fs.mkdtemp(path.join(os.tmpdir(), 'opkg-codex-agents-rev-'));
+
+    try {
+      // Set up a minimal package in the workspace
+      await writeFile(
+        path.join(workspace, '.openpackage', 'openpackage.yml'),
+        'name: test-pkg\nversion: 0.1.0\n'
+      );
+
+      // Pre-existing codex agent in the workspace
+      const tomlSource =
+        'name = "round-tripper"\n' +
+        'description = "Tests forward and reverse mappings"\n' +
+        'model = "opus"\n' +
+        'developer_instructions = "You round-trip cleanly."\n';
+      await writeFile(path.join(workspace, '.codex', 'agents', 'round-tripper.toml'), tomlSource);
+
+      const result = runCli(
+        ['add', path.join(workspace, '.codex', 'agents', 'round-tripper.toml')],
+        workspace,
+        { CI: 'true' }
+      );
+
+      assert.equal(
+        result.code,
+        0,
+        `opkg add should succeed.\nstdout: ${result.stdout}\nstderr: ${result.stderr}`
+      );
+
+      const mdPath = path.join(workspace, '.openpackage', 'agents', 'round-tripper.md');
+      const md = await fs.readFile(mdPath, 'utf8');
+
+      assert.match(md, /^---/, 'output should begin with frontmatter delimiter');
+      assert.match(md, /name: round-tripper/);
+      assert.match(md, /description: Tests forward and reverse mappings/);
+      assert.match(md, /model: opus/);
+      assert.match(md, /You round-trip cleanly\./);
+    } finally {
+      await fs.rm(workspace, { recursive: true, force: true });
+    }
+  });
+});

--- a/tests/integration/codex-skill-bundle.test.ts
+++ b/tests/integration/codex-skill-bundle.test.ts
@@ -39,37 +39,22 @@ async function writeFile(filePath: string, content: string): Promise<void> {
 }
 
 describe('codex skill bundle integration', () => {
-  it('installs a root skill package into the official Codex .agents/skills layout', async () => {
+  it('installs a skills/<name>/ package into the official Codex .agents/skills layout', async () => {
     const workspace = await fs.mkdtemp(path.join(os.tmpdir(), 'opkg-codex-workspace-'));
     const sourceRoot = await fs.mkdtemp(path.join(os.tmpdir(), 'opkg-codex-source-'));
-    const skillDir = path.join(sourceRoot, 'decomplect');
+    const pkgDir = path.join(sourceRoot, 'decomplect-pkg');
+    const skillDir = path.join(pkgDir, 'skills', 'decomplect');
 
     try {
       await fs.mkdir(path.join(workspace, '.agents'), { recursive: true });
 
-      await writeFile(
-        path.join(skillDir, 'SKILL.md'),
-        '# Decomplect\n'
-      );
-      await writeFile(
-        path.join(skillDir, 'commands', 'decomplect.md'),
-        '# Decomplect Command\n'
-      );
-      await writeFile(
-        path.join(skillDir, 'reference', 'coupling.md'),
-        '# Coupling Reference\n'
-      );
-      await writeFile(
-        path.join(skillDir, 'README.md'),
-        '# Decomplect Readme\n'
-      );
-      await writeFile(
-        path.join(skillDir, 'EXAMPLES.md'),
-        '# Decomplect Examples\n'
-      );
+      await writeFile(path.join(skillDir, 'SKILL.md'), '# Decomplect\n');
+      await writeFile(path.join(skillDir, 'references', 'coupling.md'), '# Coupling Reference\n');
+      await writeFile(path.join(skillDir, 'scripts', 'analyze.sh'), '#!/bin/sh\necho ok\n');
+      await writeFile(path.join(pkgDir, 'commands', 'decomplect.md'), '# Decomplect Command\n');
 
       const result = runCli(
-        ['install', skillDir, '--platforms', 'codex', '--force', '--conflicts', 'overwrite'],
+        ['install', pkgDir, '--platforms', 'codex', '--force', '--conflicts', 'overwrite'],
         workspace,
         { CI: 'true' }
       );
@@ -82,8 +67,7 @@ describe('codex skill bundle integration', () => {
 
       await fs.access(path.join(workspace, '.agents', 'skills', 'decomplect', 'SKILL.md'));
       await fs.access(path.join(workspace, '.agents', 'skills', 'decomplect', 'references', 'coupling.md'));
-      await fs.access(path.join(workspace, '.agents', 'skills', 'decomplect', 'references', 'README.md'));
-      await fs.access(path.join(workspace, '.agents', 'skills', 'decomplect', 'references', 'EXAMPLES.md'));
+      await fs.access(path.join(workspace, '.agents', 'skills', 'decomplect', 'scripts', 'analyze.sh'));
       await fs.access(path.join(workspace, '.codex', 'prompts', 'decomplect.md'));
 
       await assert.rejects(

--- a/tests/integration/codex-skill-bundle.test.ts
+++ b/tests/integration/codex-skill-bundle.test.ts
@@ -56,10 +56,6 @@ describe('codex skill bundle integration', () => {
         '# Decomplect Command\n'
       );
       await writeFile(
-        path.join(skillDir, 'agents', 'coupling-analyzer.md'),
-        '# Coupling Analyzer\n'
-      );
-      await writeFile(
         path.join(skillDir, 'reference', 'coupling.md'),
         '# Coupling Reference\n'
       );
@@ -86,7 +82,6 @@ describe('codex skill bundle integration', () => {
 
       await fs.access(path.join(workspace, '.agents', 'skills', 'decomplect', 'SKILL.md'));
       await fs.access(path.join(workspace, '.agents', 'skills', 'decomplect', 'commands', 'decomplect.md'));
-      await fs.access(path.join(workspace, '.agents', 'skills', 'decomplect', 'agents', 'coupling-analyzer.md'));
       await fs.access(path.join(workspace, '.agents', 'skills', 'decomplect', 'references', 'coupling.md'));
       await fs.access(path.join(workspace, '.agents', 'skills', 'decomplect', 'references', 'README.md'));
       await fs.access(path.join(workspace, '.agents', 'skills', 'decomplect', 'references', 'EXAMPLES.md'));

--- a/tests/integration/codex-skill-bundle.test.ts
+++ b/tests/integration/codex-skill-bundle.test.ts
@@ -81,7 +81,6 @@ describe('codex skill bundle integration', () => {
       );
 
       await fs.access(path.join(workspace, '.agents', 'skills', 'decomplect', 'SKILL.md'));
-      await fs.access(path.join(workspace, '.agents', 'skills', 'decomplect', 'commands', 'decomplect.md'));
       await fs.access(path.join(workspace, '.agents', 'skills', 'decomplect', 'references', 'coupling.md'));
       await fs.access(path.join(workspace, '.agents', 'skills', 'decomplect', 'references', 'README.md'));
       await fs.access(path.join(workspace, '.agents', 'skills', 'decomplect', 'references', 'EXAMPLES.md'));

--- a/tests/run-tests.ts
+++ b/tests/run-tests.ts
@@ -50,6 +50,8 @@ const testFiles: string[] = [
   'tests/core/flows/source-resolver.test.ts',
   'tests/core/flows/tool-mapping.test.ts',
   'tests/core/flows/transforms/toml-transforms.test.ts',
+  'tests/core/flows/transforms/markdown-transforms.test.ts',
+  'tests/core/flows/transforms/yaml-aliases.test.ts',
   'tests/core/flows/unified-platform-model.test.ts',
   'tests/core/flows/unit/switch-resolution.test.ts',
   'tests/core/flows/unit/to-pattern-extractor.test.ts',

--- a/tests/run-tests.ts
+++ b/tests/run-tests.ts
@@ -164,6 +164,7 @@ const testFiles: string[] = [
   // Integration
   'tests/integration/cwd-global.test.ts',
   'tests/integration/codex-skill-bundle.test.ts',
+  'tests/integration/codex-agents.test.ts',
   'tests/integration/nested-deps.test.ts',
   'tests/integration/nested-plugin-skills.test.ts',
   'tests/integration/install-flags.test.ts',


### PR DESCRIPTION
## Changes

- Fix: Codex CLI subagents were not installed to `.codex/agents/<name>.toml`
- Fix: `opkg add .codex/agents/*.toml` did not round-trip back to universal `agents/*.md`
- Fix: Goose MCP install/import threw on unregistered `json-to-yaml` / `yaml-to-json` aliases

## Dev notes

- Adds forward flow `agents/*.md → .codex/agents/*.toml` and reverse import flow `.codex/agents/*.toml → agents/*.md` in `platforms.jsonc`
- Removes two false-premise flows where `commands/` and `agents/` were swept into `.agents/skills/{leaf}/...` — a path Codex doesn't read. Drops the root-as-skill packaging shim too; the uniform `skills/**/*` flow already covers the standard layout
- Foundation commit standardizes the `$pipe` transform registry on explicit-pair aliases and adds the markdown↔JSON pair the `.md` ↔ `.toml` conversion needs. Goose YAML aliases registered as a side benefit
- Integration tests cover project + global install, filename fallback, and `opkg add` round-trip
- Partially addresses #53 — agents portion only. Plugins portion remains, tracked under #39