### PR TITLE
New: CI workflows for PR validation and release publish

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,32 @@
+name: ci
+
+on:
+  pull_request:
+    branches: [main]
+  push:
+    branches: [main]
+
+concurrency:
+  group: ci-${{ github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
+jobs:
+  validate:
+    name: validate
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: '22'
+          cache: 'npm'
+
+      - run: npm ci
+
+      - run: npm run build:check
+
+      - run: npm test
+
+      - run: npm run build

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -27,6 +27,6 @@ jobs:
 
       - run: npm run build:check
 
-      - run: npm test
-
       - run: npm run build
+
+      - run: npm test

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,0 +1,34 @@
+name: publish
+
+on:
+  release:
+    types: [published]
+
+permissions:
+  contents: read
+  id-token: write
+
+jobs:
+  publish:
+    name: publish
+    if: ${{ !github.event.release.prerelease }}
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          ref: ${{ github.event.release.tag_name }}
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: '22'
+          registry-url: 'https://registry.npmjs.org'
+          cache: 'npm'
+
+      - run: npm ci
+
+      - run: npm test
+
+      - run: npm run build
+
+      - run: npm publish --provenance --access public

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -27,8 +27,8 @@ jobs:
 
       - run: npm ci
 
-      - run: npm test
-
       - run: npm run build
+
+      - run: npm test
 
       - run: npm publish --provenance --access public


### PR DESCRIPTION
## Changes

- New: every PR and push to main runs typecheck, tests, and build via GitHub Actions
- New: `opkg` publishes to npm with provenance attestation automatically when a GitHub release is published

## Dev notes

- `ci.yml`: triggers on `pull_request` and `push` to main. `npm ci → build:check → test → build` on Node 22. Concurrency cancels superseded PR runs
- `publish.yml`: triggers on `release: published` (skipped if prerelease). Uses Trusted Publisher / OIDC, no `NPM_TOKEN` secret. Checks out the tagged commit before building. Only `opkg` (root) publishes; `packages/core` and `packages/cli` are build-only workspaces, not on the registry
- Branch protection on `main` will be configured in a follow-up once this PR's first run establishes the `validate` check name