### PR TITLE
Fix #62: declare picocolors and @clack/core as runtime dependencies

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -12,6 +12,7 @@
         "packages/*"
       ],
       "dependencies": {
+        "@clack/core": "^1.0.1",
         "@clack/prompts": "^1.0.1",
         "commander": "^14.0.0",
         "fast-fuzzy": "^1.12.0",
@@ -25,6 +26,7 @@
         "minimatch": "^10.1.1",
         "nanoid": "^5.0.7",
         "ora": "^9.3.0",
+        "picocolors": "^1.1.0",
         "prompts": "^2.4.2",
         "semver": "^7.7.2",
         "smol-toml": "^1.6.0",

--- a/package.json
+++ b/package.json
@@ -58,6 +58,7 @@
     "test": "TS_NODE_TRANSPILE_ONLY=1 node --loader ts-node/esm tests/run-tests.ts"
   },
   "dependencies": {
+    "@clack/core": "^1.0.1",
     "@clack/prompts": "^1.0.1",
     "commander": "^14.0.0",
     "fast-fuzzy": "^1.12.0",
@@ -71,6 +72,7 @@
     "minimatch": "^10.1.1",
     "nanoid": "^5.0.7",
     "ora": "^9.3.0",
+    "picocolors": "^1.1.0",
     "prompts": "^2.4.2",
     "semver": "^7.7.2",
     "smol-toml": "^1.6.0",


### PR DESCRIPTION
## Problem

Fixes #62 — `opkg add` crashes at startup on some installs with:

```
Cannot find package 'picocolors' imported from .../node_modules/opkg/packages/cli/dist/chunk-*.js
```

Reported on Homebrew/macOS and linuxbrew (Node v25). Workaround was a manual `npm i -g picocolors`.

## Root cause

The CLI bundle imports `picocolors` and `@clack/core` directly — they power the custom interactive file selector (`packages/cli/src/utils/file-selector-with-header.ts`: `@clack/core`'s `AutocompletePrompt` base class + `picocolors` for coloring). esbuild builds with `packages: 'external'`, so every npm import stays external and must be present at runtime.

Neither was declared in the **published** root `package.json`. npm only reads `package.json`, never the bundled JS, so it never installed them on opkg's behalf — they only appeared as **hoisted transitive deps** of `@clack/prompts`. Whether opkg's own chunk could resolve them came down to hoisting luck:

- Hoisted to top-level `node_modules/picocolors` → resolves → works (most npm installs + dev, which is why it went unnoticed).
- Strict / non-hoisting layout (pnpm, or npm under a version conflict) → buried at `@clack/prompts/node_modules/picocolors`, off opkg's resolution path → crash.

This is a classic phantom-dependency bug, and it had drifted **twice** (`picocolors` *and* `@clack/core`).

## Fix

Declare both in the root `dependencies`:

```diff
+    "@clack/core": "^1.0.1",
     "@clack/prompts": "^1.0.1",
+    "picocolors": "^1.1.0",
```

`@clack/core` is pinned to `^1.0.1` to dedupe with `@clack/prompts` (which pins it exactly `1.0.1`), avoiding a second copy of the `AutocompletePrompt` base class we subclass.

## Verification

Repro packs the actual build and installs it with `npm install --install-strategy=nested` (the canonical way to expose a phantom dep — no hoisting to mask it):

- **Before:** `opkg add` exits 1 with the verbatim #62 error; picocolors unreachable.
- **After:** both resolve at `node_modules/opkg/node_modules/{picocolors,@clack/core}`; `opkg add` exits 0 and runs into real logic.

Also: `npm run build` clean, `tsc` type-check clean, **123/123 tests pass**.

## Follow-up (not in this PR)

A build-time guard that diffs the built bundle's external imports against the declared root deps (fail on under-declaration) would catch this class of bug in CI — recommended, since dev hoisting always masks it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)